### PR TITLE
Use new endpoint for row deletion

### DIFF
--- a/openapi/api_v1.yaml
+++ b/openapi/api_v1.yaml
@@ -1,0 +1,802 @@
+openapi: 3.0.3
+info:
+  title: Checklist service v1
+  description: Checklist service v1
+  version: 1.0.0
+paths:
+  /:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /api/v1/checklists:
+    get:
+      summary: Get all checklists
+      operationId: getAllChecklists
+      tags:
+        - checklist
+      responses:
+        '200':
+          description: A list of checklist items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChecklistResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      summary: Create a new checklist
+      operationId: createChecklist
+      tags:
+        - checklist
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistRequest'
+      responses:
+        '201':
+          description: Checklist created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/checklists/{checklistId}:
+    get:
+      summary: Get checklist by ID
+      operationId: getChecklistById
+      tags:
+        - checklist
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+      responses:
+        '200':
+          description: A checklist item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    put:
+      summary: Update checklist by ID
+      operationId: UpdateChecklistById
+      tags:
+        - checklist
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistRequest'
+      responses:
+        '200':
+          description: A checklist item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete checklist by ID
+      operationId: DeleteChecklistById
+      tags:
+        - checklist
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+      responses:
+        '204':
+          description: Checklist deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/checklists/{checklistId}/items:
+    get:
+      summary: Get all checklist items by checklist ID
+      operationId: getAllChecklistItems
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          description: Sort order
+        - name: completed
+          in: query
+          schema:
+            type: boolean
+          description: Filter by completed status
+      responses:
+        '200':
+          description: A list of checklist items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChecklistItemResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      summary: Create a new checklist item
+      operationId: createChecklistItem
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistItemRequest'
+      responses:
+        '201':
+          description: Checklist item created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistItemResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/checklists/{checklistId}/items/{itemId}:
+    get:
+      summary: Get checklist item by checklist id and item id
+      operationId: GetChecklistItemBychecklistIdAndItemId
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+            description: Checklist item id
+      responses:
+        '200':
+           description: "Successful request"
+           content:
+              application/json:
+                  schema:
+                    $ref: '#/components/schemas/ChecklistItemResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist item or checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete checklist item by checklistId and checklistItemId
+      operationId: DeleteChecklistItemById
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+            description: Checklist item id
+      responses:
+        '204':
+          description: Checklist item deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistItemResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist item or checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      summary: Update checklist item by checklist id and item id
+      operationId: UpdateChecklistItemBychecklistIdAndItemId
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+            description: Checklist item id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateChecklistItemRequest'
+      responses:
+        '200':
+              description: Checklist item updated
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/ChecklistItemResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        
+      description: Checklist item or checklist not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+
+  /api/v1/checklists/{checklistId}/items/{itemId}/change-order:
+    patch:
+      summary: Change checklist item order number
+      operationId: ChangeChecklistItemOrderNumber
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist item id
+        - name: sortOrder
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
+          required: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+               - newOrderNumber
+              properties:
+                newOrderNumber:
+                  type: number
+                  x-go-type: uint
+                  format: int64
+                  minimum: 1
+      responses:
+        '200':
+          description: Successfully updated order number for checklist item
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  oldOrderNumber:
+                    type: number
+                    x-go-type: uint
+                    format: int64
+                    minimum: 1
+                  newOrderNumber:
+                    type: number
+                    x-go-type: uint
+                    format: int64
+                    minimum: 1
+        '404':
+          description: checklist item or checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/v1/checklists/{checklistId}/items/{itemId}/rows:
+    post:
+      summary: Create checklist item row
+      operationId: createChecklistItemRow
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist item id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateChecklistItemRowRequest'
+      responses:
+        '201':
+          description: Checklist item row created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecklistItemRowResponse'
+        '404':
+          description: Checklist item or checklist not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/v1/checklists/{checklistId}/items/{itemId}/rows/{rowId}:
+    delete:
+      summary: Delete checklist item row by checklistId, itemId and rowId
+      operationId: DeleteChecklistItemRow
+      tags:
+        - checklistItem
+      parameters:
+        - name: checklistId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist ID
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist item id
+        - name: rowId
+          in: path
+          required: true
+          schema:
+            type: number
+            x-go-type: uint
+            minimum: 1
+            format: int64
+          description: Checklist item row id
+      responses:
+        '204':
+          description: Checklist item row deleted
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Checklist item row or checklist item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+          nullable: false
+          minLength: 0
+      required:
+        - code
+        - message
+    CreateChecklistItemRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        rows:
+            type: array
+            items:
+                $ref: '#/components/schemas/CreateOrUpdateChecklistItemRowRequest'
+      required:
+        - name
+    UpdateChecklistItemRequest:
+      type: object
+      properties:
+        id:
+          x-go-type: uint
+          type: integer
+          nullable: false
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        completed:
+          type: boolean
+          nullable: false
+        rows:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                x-go-type: uint
+                format: int32
+                nullable: false
+                minimum: 1
+              name:
+                type: string
+                nullable: false
+                minLength: 1
+              completed:
+                type: boolean
+                nullable: true
+                default: false
+            required:
+              - name
+              - completed
+              - id
+      required:
+        - id
+        - name
+        - completed
+        - rows
+    ChecklistItemResponse:
+      type: object
+      properties:
+        id:
+          type: number
+          x-go-type: uint
+          nullable: false
+          minimum: 1
+          format: int64
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        completed:
+          type: boolean
+          nullable: false
+          default: false
+        orderNumber:
+          type: number
+          x-go-type: uint
+          nullable: false
+          minimum: 1
+          format: int64
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChecklistItemRowResponse'
+      required:
+        - name
+        - completed
+        - id
+        - orderNumber
+        - rows
+    ChecklistItemRowResponse:
+      type: object
+      properties:
+        id:
+          type: number
+          format: int64
+          minimum: 0
+          x-go-type: uint
+          nullable: false
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        completed:
+          type: boolean
+          nullable: true
+          default: false
+      required:
+        - id
+        - name
+        - completed
+    CreateOrUpdateChecklistItemRowRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        completed:
+          type: boolean
+          nullable: true
+          default: false
+      required:
+        - name
+        - completed
+    CreateChecklistItemRowRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateOrUpdateChecklistItemRowRequest'
+    ChecklistUpdateAndCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+      required:
+        - name
+    CreateChecklistRequest:
+      allOf:
+        - $ref: '#/components/schemas/ChecklistUpdateAndCreateRequest'
+    UpdateChecklistRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ChecklistUpdateAndCreateRequest'
+    ChecklistResponse:
+      type: object
+      properties:
+        id:
+          type: number
+          x-go-type: uint
+          nullable: false
+          format: int64
+          minimum: 1
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChecklistItemResponse'
+      required:
+        - name
+        - id
+

--- a/orval.config.js
+++ b/orval.config.js
@@ -1,7 +1,7 @@
 /** @type {import('orval').Config} */
 module.exports = {
   api: {
-    input: 'https://raw.githubusercontent.com/raunlo/ChecklistApplication/f192852d1f00fdc419dd757480363067e9a95a27/openapi/api_v1.yaml', // or local path
+    input: './openapi/api_v1.yaml', // or local path
     output: {
       mode: 'tags-split',
       target: './src/api/',   // your generated code will appear here

--- a/src/api/checklist-item/checklist-item.ts
+++ b/src/api/checklist-item/checklist-item.ts
@@ -360,3 +360,53 @@ export const useCreateChecklistItemRow = <TError = AxiosError<Error>>(
     ...query
   }
 }
+/**
+ * @summary Delete checklist item row by checklistId, itemId and rowId
+ */
+export const deleteChecklistItemRow = (
+    checklistId: number,
+    itemId: number,
+    rowId: number, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<void>> => {
+    return axios.delete(
+      `/api/v1/checklists/${checklistId}/items/${itemId}/rows/${rowId}`,options
+    );
+  }
+
+
+
+export const getDeleteChecklistItemRowMutationFetcher = (checklistId: number,
+    itemId: number,
+    rowId: number, options?: AxiosRequestConfig) => {
+  return (_: string, __: { arg: Arguments }): Promise<AxiosResponse<void>> => {
+    return deleteChecklistItemRow(checklistId, itemId, rowId, options);
+  }
+}
+export const getDeleteChecklistItemRowMutationKey = (checklistId: number,
+    itemId: number,
+    rowId: number,) => `/api/v1/checklists/${checklistId}/items/${itemId}/rows/${rowId}` as const;
+
+export type DeleteChecklistItemRowMutationResult = NonNullable<Awaited<ReturnType<typeof deleteChecklistItemRow>>>
+export type DeleteChecklistItemRowMutationError = AxiosError<Error>
+
+/**
+ * @summary Delete checklist item row by checklistId, itemId and rowId
+ */
+export const useDeleteChecklistItemRow = <TError = AxiosError<Error>>(
+  checklistId: number,
+    itemId: number,
+    rowId: number, options?: { swr?:SWRMutationConfiguration<Awaited<ReturnType<typeof deleteChecklistItemRow>>, TError, string, Arguments, Awaited<ReturnType<typeof deleteChecklistItemRow>>> & { swrKey?: string }, axios?: AxiosRequestConfig }
+) => {
+
+  const {swr: swrOptions, axios: axiosOptions} = options ?? {}
+
+  const swrKey = swrOptions?.swrKey ?? getDeleteChecklistItemRowMutationKey(checklistId,itemId,rowId);
+  const swrFn = getDeleteChecklistItemRowMutationFetcher(checklistId,itemId,rowId,axiosOptions);
+
+  const query = useSWRMutation(swrKey, swrFn, swrOptions)
+
+  return {
+    swrKey,
+    ...query
+  }
+}

--- a/src/components/checklist-item.tsx
+++ b/src/components/checklist-item.tsx
@@ -9,7 +9,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Plus, Trash2 } from "lucide-react";
 import {ChecklistItemResponse, ChecklistItemRowResponse, UpdateChecklistItemRequest} from "@/api/checklistServiceV1.schemas"
 import { CheckedState } from "@radix-ui/react-checkbox";
-import { deleteChecklistItemById, createChecklistItemRow, updateChecklistItemBychecklistIdAndItemId } from "@/api/checklist-item/checklist-item"
+import { deleteChecklistItemById, createChecklistItemRow, updateChecklistItemBychecklistIdAndItemId, deleteChecklistItemRow } from "@/api/checklist-item/checklist-item"
 import { axiousProps } from "@/lib/axios";
 import { it } from "node:test";
 
@@ -86,8 +86,12 @@ export function ChecklistItemComponent({
   const deleteRow = async (rowId : number) => {
     item.rows = item.rows.filter(row => row.id !== rowId)
     onChecklistItemUpdate(item)
-
-    await updateItem(item)
+    await deleteChecklistItemRow(
+        checklistId,
+        item.id,
+        rowId,
+        axiousProps
+    )
   }
 
   const handleRowCompleted = async (rowItem: ChecklistItemRowResponse, checked: boolean) => {


### PR DESCRIPTION
## Summary
- use local OpenAPI spec and regenerate client
- call deleteChecklistItemRow endpoint when removing a row

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: Argument of type '(key: any) => string' is not assignable to parameter of type '{ checklistId: string; itemId: string; data: CreateSubItem; }'...)*

------
https://chatgpt.com/codex/tasks/task_e_68974be4e32483239cbd6ada748785e6