### PR TITLE
Update order numbers when reordering checklist items

### DIFF
--- a/src/hooks/use-checklist.ts
+++ b/src/hooks/use-checklist.ts
@@ -126,8 +126,13 @@ export function useChecklist(checklistId?: number): ChecklistHookResult {
     const newList = [...items];
     const [moved] = newList.splice(from, 1);
     newList.splice(to, 0, moved);
-    mutateItems(newList, false);
-    if (moved?.id && targetOrderNumber) {
+
+    const reordered = newList.map((item, idx) => ({
+      ...item,
+      orderNumber: idx,
+    }));
+    mutateItems(reordered, false);
+    if (moved?.id && targetOrderNumber != null) {
       try {
         await changeChecklistItemOrderNumber(
           checklistId,


### PR DESCRIPTION
## Summary
- Recalculate orderNumber for all checklist items when reordering so local cache matches new order
- Guard against null/undefined target order numbers before calling API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6897e4a43de08323afad8ff3b25ae68a