### PR TITLE
Remove green hover background from ghost buttons

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,7 +16,7 @@ const buttonVariants = cva(
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "bg-transparent hover:bg-transparent",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## Summary
- remove accent hover background from ghost buttons to eliminate green flash on hover

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a07d0086508323bb5a70fd41e765a2