### PR TITLE
feat: add refresh interval to checklist hook

### DIFF
--- a/src/components/checklist-card.tsx
+++ b/src/components/checklist-card.tsx
@@ -21,7 +21,7 @@ type ChecklistCardProps = {
 
 export const ChecklistCard = forwardRef<ChecklistCardHandle, ChecklistCardProps>(
   ({ checklist }, ref): JSX.Element => {
-  const { items, addItem, reorderItem } = useChecklist(checklist.id);
+  const { items, addItem, reorderItem } = useChecklist(checklist.id, { refreshInterval: 10000 });
 
   useImperativeHandle(ref, () => ({
       async handleReorder(from, to) {

--- a/src/hooks/use-checklist.ts
+++ b/src/hooks/use-checklist.ts
@@ -20,7 +20,6 @@ import {
 import { useGetAllChecklists } from "@/api/checklist/checklist";
 import { axiousProps } from "@/lib/axios";
 import { ChecklistItem, ChecklistItemRow } from "@/components/shared/types";
-import {AxiosResponse} from "axios"
 
 interface ChecklistHookResult {
   checklists: ChecklistResponse[];
@@ -35,12 +34,21 @@ interface ChecklistHookResult {
   deleteRow: (itemId: number | null, rowId: number | null) => Promise<void>;
 }
 
-export function useChecklist(checklistId?: number): ChecklistHookResult {
+interface ChecklistHookOptions {
+  refreshInterval?: number;
+}
+
+export function useChecklist(
+  checklistId?: number,
+  options: ChecklistHookOptions = {},
+): ChecklistHookResult {
+  const { refreshInterval } = options;
+
   const {
     data: checklistRes,
     error,
     isLoading: isChecklistsLoading,
-  } = useGetAllChecklists({ axios: axiousProps });
+  } = useGetAllChecklists({ axios: axiousProps, swr: { refreshInterval } });
 
   const { data: items = [], mutate: mutateItems } = useSWR<ChecklistItem[]>(
     checklistId ? ["checklist-items", checklistId] : null,
@@ -63,6 +71,7 @@ export function useChecklist(checklistId?: number): ChecklistHookResult {
           })) ?? null,
       }));
     },
+    { refreshInterval },
   );
 
   const addItem = async (item: ChecklistItem) => {


### PR DESCRIPTION
## Summary
- allow checklist data to refresh on a set interval
- refresh checklist items every 10 seconds in card component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a07fa3d2c08323872dbb5684ea661d