### PR TITLE
fix: keep checklist order when API reorder is slow

### DIFF
--- a/src/hooks/use-checklist.ts
+++ b/src/hooks/use-checklist.ts
@@ -149,7 +149,8 @@ export function useChecklist(
       const newList = [...items];
       const [moved] = newList.splice(from, 1);
       newList.splice(to, 0, moved);
-      mutateItems(newList, false);
+      const previousItems = [...items];
+      mutateItems(newList, { revalidate: false });
       if (moved?.id && targetOrderNumber) {
         try {
           await changeChecklistItemOrderNumber(
@@ -160,7 +161,7 @@ export function useChecklist(
             axiousProps,
           );
         } catch (e) {
-          mutateItems();
+          mutateItems(previousItems, { revalidate: false });
           if (numberRetries === 1) retry = true;
         }
       }


### PR DESCRIPTION
## Summary
- prevent item list from reverting to old order during slow reorder requests by reverting locally instead of refetching

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)
- `npm run typecheck` (no output, needed manual termination)


------
https://chatgpt.com/codex/tasks/task_e_68a09437c90c832383c4a281a018da5a