### PR TITLE
Fix item marked complete when adding sub-item row

### DIFF
--- a/src/hooks/use-checklist.ts
+++ b/src/hooks/use-checklist.ts
@@ -179,8 +179,11 @@ export function useChecklist(
     mutateItems(
       items.map((item) =>
         item.id === itemId
-          ? { ...item, completed: item.completed ? false: true,
-             rows: [...(item.rows ?? []), row] }
+          ? {
+              ...item,
+              completed: item.completed ? false : item.completed,
+              rows: [...(item.rows ?? []), row],
+            }
           : item,
       ),
       false,


### PR DESCRIPTION
## Summary
- prevent checklist items from being optimistically marked complete when adding a new row

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a098b582e88323ba5a8e10bbb5bb31