### PR TITLE
Configure PRIVATE_API_BASE_URL for Firebase builds and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Environment variables
+
+The application expects `PRIVATE_API_BASE_URL` to be available at build and runtime.
+When deploying with Firebase Hosting, you can provide it in `firebase.json` under
+`hosting.build.env` and in `apphosting.yaml` under `runConfig.env`.

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -16,6 +16,9 @@ runConfig:
   # Explicitly set the CPU and memory to low values.
   cpu: 1
   memoryMiB: 512
+  env:
+    - key: PRIVATE_API_BASE_URL
+      value: https://example.com
 
 # Managed an automated, zero-config CI/CD pipeline.
 # https://firebase.google.com/docs/app-hosting/configure-ci-cd

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -18,7 +18,7 @@ runConfig:
   memoryMiB: 512
   env:
     - key: PRIVATE_API_BASE_URL
-      value: https://example.com
+      value: https://checklistapp-159775351199.europe-west1.run.app
 
 # Managed an automated, zero-config CI/CD pipeline.
 # https://firebase.google.com/docs/app-hosting/configure-ci-cd

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,11 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "build": {
+      "env": {
+        "PRIVATE_API_BASE_URL": "https://example.com"
+      }
+    },
     "frameworksBackend": {
       "region": "europe-west1"
     }

--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,7 @@
     ],
     "build": {
       "env": {
-        "PRIVATE_API_BASE_URL": "https://example.com"
+        "PRIVATE_API_BASE_URL": "https://checklistapp-159775351199.europe-west1.run.app"
       }
     },
     "frameworksBackend": {


### PR DESCRIPTION
## Summary
- define PRIVATE_API_BASE_URL for Cloud Build via firebase.json
- inject PRIVATE_API_BASE_URL into runtime using apphosting.yaml
- document the required environment variable in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint plugin setup prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a88b796ff48323b2f38a2ef693b218