### PR TITLE
Handle missing PRIVATE_API_BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ To get started, take a look at src/app/page.tsx.
 
 ## Environment variables
 
-The application expects `PRIVATE_API_BASE_URL` to be available at build and runtime.
-When deploying with Firebase Hosting, you can provide it in `firebase.json` under
-`hosting.build.env` and in `apphosting.yaml` under `runConfig.env`.
+The application expects `PRIVATE_API_BASE_URL` to be available at runtime. Builds
+can proceed without it, but the proxy API routes will return an error until the
+variable is set. When deploying with Firebase Hosting, you can provide it in
+`firebase.json` under `hosting.build.env` and in `apphosting.yaml` under
+`runConfig.env`.


### PR DESCRIPTION
## Summary
- Avoid build failures when `PRIVATE_API_BASE_URL` is unset by checking for it at request time.
- Document runtime requirement for `PRIVATE_API_BASE_URL` in README.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8edfba82483238446115c90360c10