### PR TITLE
Fix proxy route build errors

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -30,7 +30,7 @@ const clientCache = new Map<string, IdTokenClient | MockIdTokenClient>();
 
 async function getAuthenticatedClient(baseUrl: string) {
   if (clientCache.has(baseUrl)) {
-    return clientCache.get(baseUrl)!
+    return clientCache.get(baseUrl)!;
   }
   if (useMockAuth) {
     console.log('Using mock authentication client');
@@ -40,7 +40,7 @@ async function getAuthenticatedClient(baseUrl: string) {
   }
   try {
     console.log(`Authenticating for audience: ${baseUrl}`);
-    client = await auth.getIdTokenClient(baseUrl);
+    const authedClient = await auth.getIdTokenClient(baseUrl);
     console.log('Successfully created authenticated client.');
     clientCache.set(baseUrl, authedClient);
     return authedClient;
@@ -58,7 +58,8 @@ async function handler(req: NextRequest) {
     );
     return NextResponse.json(
       { message: 'PRIVATE_API_BASE_URL is not configured' },
-      { status: 500 }
+      { status: 500 },
+    );
   }
 
   try {


### PR DESCRIPTION
## Summary
- properly instantiate and cache auth client in proxy route
- handle missing PRIVATE_API_BASE_URL configuration gracefully

## Testing
- `npm run build`
- `npm run typecheck`
- `npm run lint` *(fails: requires setup, prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de8a44b883239f8ac8762aa358a1