### PR TITLE
Enable HTTP keep-alive for Axios requests

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,12 +1,16 @@
 
 import Axios, { AxiosError, AxiosRequestConfig, CreateAxiosDefaults } from 'axios';
+import http from 'http';
+import https from 'https';
 
 // The base URL should always be the relative path to our proxy.
 const NEXT_PUBLIC_API_BASE_URL = '/api/proxy';
 
-const axiousProps = {
-  baseURL: NEXT_PUBLIC_API_BASE_URL
-}
+const axiousProps: AxiosRequestConfig = {
+  baseURL: NEXT_PUBLIC_API_BASE_URL,
+  httpAgent: new http.Agent({ keepAlive: true }),
+  httpsAgent: new https.Agent({ keepAlive: true }),
+};
 // The base URL is now the local proxy endpoint.
 const axiosInstance = Axios.create(axiousProps as CreateAxiosDefaults);
 


### PR DESCRIPTION
## Summary
- configure Axios to reuse HTTP/HTTPS connections with keep-alive agents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acec82c0d8832391a6eadf681cb45c